### PR TITLE
Update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: /go/src/github.com/Clever/ddb-to-es
     docker:
     - image: circleci/golang:1.10.3-stretch
-    - image: levlaz/elasticsearch-docker-ci:5.1.1
+    - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Process DynamoDB streams and INDEX, MODIFY, DELETE Elasticsearch document
 
-Owned by TODO.
+Owned by eng-infra.
 
 ## Deploying
 


### PR DESCRIPTION
Builds are failing on circleci because the app can't find an Elasticsearch node when attempting to run the tests.
Error:
`Could not connect to cluster: health check timeout: Head http://localhost:9200: dial tcp 127.0.0.1:9200: connect: connection refused: no Elasticsearch node available`

The cluster that it's writing to is on version 6.3.1

Here's where I found the docker image: https://www.docker.elastic.co/#elasticsearch-6-3-2