### PR TITLE
Provide Elasticsearch index name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ddb-to-es
 
-Process DynamoDB streams and INDEX, MODIFY, DELETE Elasticsearch document
+Process DynamoDB streams and INDEX, MODIFY, DELETE Elasticsearch documents
 
 Owned by eng-infra.
 

--- a/cmd/dynamodb/main_test.go
+++ b/cmd/dynamodb/main_test.go
@@ -39,30 +39,6 @@ func TestProcessRecords(t *testing.T) {
 	}
 }
 
-func TestIndexNameParsing(t *testing.T) {
-	tests := []struct {
-		arn   events.DynamoDBEventRecord
-		table string
-	}{
-		{
-			arn: events.DynamoDBEventRecord{
-				EventSourceArn: "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
-			},
-			table: "ExampleTableWithStream",
-		},
-		{
-			arn: events.DynamoDBEventRecord{
-				EventSourceArn: "arn:aws:dynamodb:us-west-1:589:table/workflow-manager-prod-workflows/stream/2017-12-07T23:33:03.914",
-			},
-			table: "workflow-manager-prod-workflows",
-		},
-	}
-
-	for _, test := range tests {
-		assert.Equal(t, indexName(test.arn), test.table)
-	}
-}
-
 func loadDynamoDBEvent(t *testing.T) events.DynamoDBEvent {
 	// 1. read JSON from file
 	inputJson, err := ioutil.ReadFile("./testdata/dynamodb-event.json")

--- a/es/db_test.go
+++ b/es/db_test.go
@@ -34,7 +34,8 @@ func TestWriteDocs(t *testing.T) {
 		},
 	}
 
-	db, err := NewDB(&DBConfig{URL: "http://localhost:9200"}, logger.New("test"))
+	testIndex := "testIndex"
+	db, err := NewDB(&DBConfig{URL: "http://localhost:9200"}, testIndex, logger.New("test"))
 	assert.NoError(t, err)
 
 	for _, test := range tests {
@@ -48,7 +49,8 @@ func TestWriteDocsComplexBatch(t *testing.T) {
 	err := json.Unmarshal([]byte(docsJSON), docs)
 	assert.NoError(t, err)
 
-	db, err := NewDB(&DBConfig{URL: "http://localhost:9200"}, logger.New("test"))
+	testIndex := "testIndex"
+	db, err := NewDB(&DBConfig{URL: "http://localhost:9200"}, testIndex, logger.New("test"))
 	assert.NoError(t, err)
 	err = db.WriteDocs(*docs)
 	assert.NoError(t, err)

--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -2,7 +2,7 @@ run:
   type: lambda/us-west-1
 env:
   - ELASTICSEARCH_URL
-  - INDEX_PREFIX
+  - ELASTICSEARCH_INDEX
   - FAIL_ON_ERROR
   - DYNAMODB_STREAM_ARN
 resources:


### PR DESCRIPTION
The Elasticsearch index name is computed dynamically for each document given by: `INDEX_PREFIX` + DynamoDB table name. This change provides the index as an environment variable instead of deriving it from the DynamoDB table name. This gives us the flexibility to specify a new index to write to even when the DynamoDB table remains the same. A side benefit is that the index name is not computed for each document request. 

I tested that events from the ddb stream end up in Elasticsearch as before.

https://github.com/Clever/ark-config/pull/1822