### PR TITLE
ignore stateMachine when sending workflows to ES

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,171 +2,116 @@
 
 
 [[projects]]
-  digest = "1:deba4f4561cc7490127f599626c78cbfe972ffacc8edfaf77710de8922e0ae77"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "events",
     "lambda",
     "lambda/handlertrace",
     "lambda/messages",
-    "lambdacontext",
+    "lambdacontext"
   ]
-  pruneopts = ""
   revision = "4c210d7623089d36b6bb6febf5a5e553bf73fbfb"
   version = "v1.11.1"
 
 [[projects]]
-  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:17a07b60ea50bffc1e8bd84cf4f1e5fcc07f9a5f1c50bbbe3baebc91664fb772"
   name = "github.com/jteeuwen/go-bindata"
   packages = [
     ".",
-    "go-bindata",
+    "go-bindata"
   ]
-  pruneopts = ""
   revision = "6025e8de665b31fa74ab1a66f2cddd8c0abf887e"
 
 [[projects]]
   branch = "master"
-  digest = "1:ccc20cacf54eb16464dad02efa1c14fa7c0b9e124639b0d2a51dcc87b0154e4c"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
-  pruneopts = ""
   revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
-  digest = "1:208320a64803b8cda4f8263d3cdc30dd04e9c871ae5e6cfc3d862e263da2e51d"
   name = "github.com/olivere/elastic"
   packages = [
     "config",
-    "uritemplates",
+    "uritemplates"
   ]
-  pruneopts = ""
   revision = "c51e74f9bcab8906a2f6cf5660dac396ba51b3d6"
   version = "v6.1.4"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
-  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:80970263f7b4c92a2045e9570f6119a72dc25a6e996510edb1ec54014d09ae24"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require",
+    "require"
   ]
-  pruneopts = ""
   revision = "85f2b59c4459e5bf57488796be8c3667cb8246d6"
 
 [[projects]]
   branch = "master"
-  digest = "1:dd275b17b08ad316ab1e69396a09085b65b0a728869bd406d0515f2f08ad4571"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
-  pruneopts = ""
   revision = "6fe8760cad3569743d51ddbb243b26f8456742dc"
 
 [[projects]]
   branch = "master"
-  digest = "1:feb667646650e600036a4731f959e746eb755970fc2c8a3d54c66a0cde7ac69d"
   name = "github.com/xeipuuv/gojsonreference"
   packages = ["."]
-  pruneopts = ""
   revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
 
 [[projects]]
   branch = "master"
-  digest = "1:61c4090eb4f4c7941e77aa64c281f3f47983a68f4466c63b7471bfa4d739be50"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  pruneopts = ""
   revision = "511d08a359d14c0dd9c4302af52ee9abb6f93c2a"
 
 [[projects]]
-  digest = "1:ebe5a08de85b249031c22bdf7ea4120be2b8e4751cb647ef8aa829774aa87225"
   name = "gopkg.in/Clever/kayvee-go.v6"
   packages = [
     ".",
     "logger",
-    "router",
+    "router"
   ]
-  pruneopts = ""
   revision = "1e2557bcbd6982e6303c364505d1c129ede8f2ee"
   version = "v6.17.0"
 
 [[projects]]
-  digest = "1:598f5e295ba83da7aa694f327e59a39bcaa5520d556cf4e349bbd61c2b4513fe"
   name = "gopkg.in/olivere/elastic.v6"
   packages = ["."]
-  pruneopts = ""
   revision = "9a5942842e80bd3c67c6bf9385a32a6c29eba0e4"
   version = "v6.2.19"
 
 [[projects]]
   branch = "v2"
-  digest = "1:cd78af685c4c12af0f2e9526f504ab3b18ef06130b325729e096dfe5a807ea86"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "1244d3ce02e3e1c16820ada0bae506b6c479f106"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/aws/aws-lambda-go/events",
-    "github.com/aws/aws-lambda-go/lambda",
-    "github.com/aws/aws-lambda-go/lambda/handlertrace",
-    "github.com/aws/aws-lambda-go/lambda/messages",
-    "github.com/aws/aws-lambda-go/lambdacontext",
-    "github.com/davecgh/go-spew/spew",
-    "github.com/jteeuwen/go-bindata",
-    "github.com/jteeuwen/go-bindata/go-bindata",
-    "github.com/mailru/easyjson",
-    "github.com/mailru/easyjson/buffer",
-    "github.com/mailru/easyjson/jlexer",
-    "github.com/mailru/easyjson/jwriter",
-    "github.com/olivere/elastic/config",
-    "github.com/olivere/elastic/uritemplates",
-    "github.com/pkg/errors",
-    "github.com/pmezard/go-difflib/difflib",
-    "github.com/stretchr/testify/assert",
-    "github.com/stretchr/testify/require",
-    "github.com/xeipuuv/gojsonpointer",
-    "github.com/xeipuuv/gojsonreference",
-    "github.com/xeipuuv/gojsonschema",
-    "gopkg.in/Clever/kayvee-go.v6",
-    "gopkg.in/Clever/kayvee-go.v6/logger",
-    "gopkg.in/Clever/kayvee-go.v6/router",
-    "gopkg.in/olivere/elastic.v6",
-    "gopkg.in/yaml.v2",
-  ]
+  inputs-digest = "aa514f353bda123fdecf2d8ac2e9e53032f9dd3d210067c4f0b81b9efb888e6d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/dynamodb/main_test.go
+++ b/cmd/dynamodb/main_test.go
@@ -45,9 +45,20 @@ func TestProcessRecords(t *testing.T) {
 						"IntegerNumber":  "123",
 						"List":           []interface{}{"Cookies", "Coffee", "3.14159"},
 						"Map": map[string]interface{}{
-							"Age":                        "35",
-							"Name":                       "Joe",
-							"stateMachineOtherFieldName": map[string]interface{}{"NumStates": "1", "State1": "state 1"}},
+							"Age":  "35",
+							"Name": "Joe",
+							"Workflow": map[string]interface{}{
+								"workflowDefinition": map[string]interface{}{
+									"stateMachine": map[string]interface{}{
+										"NumStates": "1",
+										"State1":    "state 1",
+									},
+								},
+							},
+						},
+						"Workflow": map[string]interface{}{
+							"workflowDefinition": map[string]interface{}{},
+						},
 						"NumberSet": []string{"1234", "567.8"},
 						"String":    "Hello",
 						"StringSet": []string{"Giraffe", "Zebra"},

--- a/cmd/dynamodb/main_test.go
+++ b/cmd/dynamodb/main_test.go
@@ -19,11 +19,45 @@ func (db *MockDB) WriteDocs(docs []es.Doc) error {
 func TestProcessRecords(t *testing.T) {
 	tests := []struct {
 		request events.DynamoDBEvent
+		docs    []es.Doc
 		err     error
 	}{
 		{
 			request: loadDynamoDBEvent(t),
-			err:     nil,
+			docs: []es.Doc{
+				es.Doc{
+					Op: "insert",
+					ID: "data|binary",
+					Item: map[string]interface{}{
+						"asdf1": []uint8{0x0, 0x1, 0x2a, 0x41},
+						"asdf2": [][]uint8{[]uint8{0x0, 0x1, 0x2a, 0x41}, []uint8{0x41, 0x2a, 0x1, 0x0}},
+						"key":   "binary", "val": "data"},
+				},
+				es.Doc{
+					Op: "insert",
+					ID: "data|binary",
+					Item: map[string]interface{}{
+						"Binary":         []uint8{0x0, 0x1, 0x2a, 0x41},
+						"BinarySet":      [][]uint8{[]uint8{0x0, 0x1, 0x2a, 0x41}, []uint8{0x0, 0x1, 0x2a, 0x41}},
+						"Boolean":        true,
+						"EmptyStringSet": []string{},
+						"FloatNumber":    "123.45",
+						"IntegerNumber":  "123",
+						"List":           []interface{}{"Cookies", "Coffee", "3.14159"},
+						"Map": map[string]interface{}{
+							"Age":                        "35",
+							"Name":                       "Joe",
+							"stateMachineOtherFieldName": map[string]interface{}{"NumStates": "1", "State1": "state 1"}},
+						"NumberSet": []string{"1234", "567.8"},
+						"String":    "Hello",
+						"StringSet": []string{"Giraffe", "Zebra"},
+						"asdf1":     []uint8{0x0, 0x1, 0x2a, 0x41},
+						"asdf2":     [][]uint8{[]uint8{0x0, 0x1, 0x2a, 0x41}, []uint8{0x41, 0x2a, 0x1, 0x0}, []uint8{0x0, 0x1, 0x2a, 0x41}},
+						"b2":        []uint8{0xb5, 0xeb, 0x2d}, "key": "binary", "val": "data",
+					},
+				},
+			},
+			err: nil,
 		},
 		{
 			request: events.DynamoDBEvent{
@@ -34,8 +68,9 @@ func TestProcessRecords(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := processRecords(test.request.Records, &MockDB{})
+		docs, err := processRecords(test.request.Records, &MockDB{})
 		assert.Equal(t, test.err, err)
+		assert.Equal(t, test.docs, docs)
 	}
 }
 

--- a/cmd/dynamodb/testdata/dynamodb-event.json
+++ b/cmd/dynamodb/testdata/dynamodb-event.json
@@ -100,6 +100,24 @@
               }
             ]
           },
+          "Workflow": {
+            "M": {
+              "workflowDefinition": {
+                "M": {
+                  "stateMachine": {
+                    "M": {
+                      "State1": {
+                        "S": "state 1"
+                      },
+                      "NumStates": {
+                        "N": "1"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
           "Map": {
             "M": {
               "Name": {
@@ -108,23 +126,21 @@
               "Age": {
                 "N": "35"
               },
-              "stateMachine": {
+              "Workflow": {
                 "M": {
-                  "State1": {
-                    "S": "state 1"
-                  },
-                  "NumStates": {
-                    "N": "1"
-                  }
-                }
-              },
-              "stateMachineOtherFieldName": {
-                "M": {
-                  "State1": {
-                    "S": "state 1"
-                  },
-                  "NumStates": {
-                    "N": "1"
+                  "workflowDefinition": {
+                    "M": {
+                      "stateMachine": {
+                        "M": {
+                          "State1": {
+                            "S": "state 1"
+                          },
+                          "NumStates": {
+                            "N": "1"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/cmd/dynamodb/testdata/dynamodb-event.json
+++ b/cmd/dynamodb/testdata/dynamodb-event.json
@@ -107,6 +107,26 @@
               },
               "Age": {
                 "N": "35"
+              },
+              "stateMachine": {
+                "M": {
+                  "State1": {
+                    "S": "state 1"
+                  },
+                  "NumStates": {
+                    "N": "1"
+                  }
+                }
+              },
+              "stateMachineOtherFieldName": {
+                "M": {
+                  "State1": {
+                    "S": "state 1"
+                  },
+                  "NumStates": {
+                    "N": "1"
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
see conversation here https://clever.slack.com/archives/C08G6CNMN/p1597336900326700

We have 4000 fields in the index because we're sending so many fields for all the states of the workflows, which is bad for performance of the cluster.

**Testing**
Added a test and included two map fields, one named `stateMachine` and one named `stateMachineOtherFieldName` and confirmed that the first was ignored but the second was included.