### PR TITLE
update lambda.mk

### DIFF
--- a/lambda.mk
+++ b/lambda.mk
@@ -1,7 +1,7 @@
 # This is the default Clever lambda Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-LAMBDA_MK_VERSION := 0.1.0
+LAMBDA_MK_VERSION := 0.2.3
 SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go
@@ -10,12 +10,31 @@ GOPATH ?= $(HOME)/go
 # arg1: pkg path
 # arg2: executable name
 define lambda-build-go
-GOOS=linux go build -o bin/$(2) $(1)
-(cd bin && zip $(2).zip $(2))
+@GOOS=linux go build -o bin/$(2) $(1)
+# provided.al2 requires executable to be named `boostrap`
+# During migration include both `bootstrap` and `$(2)` in the
+# zip file, and once everything is on al2, remove `$(2)`
+@cp bin/$(2) bin/bootstrap
+@(cd bin && zip $(2).zip $(2) bootstrap)
+endef
+
+# lambda-build-node: builds a lambda function written in Node
+# arg1: app/repo name
+define lambda-build-node
+@echo 'Compiling...'
+@node_modules/.bin/tsc --outDir bin/
+@echo 'Prepping dependencies...'
+@rm -r node_modules/
+@npm install --quiet --production
+@cp -r node_modules/ bin/node_modules/
+@echo 'Creating zip file...'
+@(cd bin/ && zip -qr $(1).zip *)
+@echo 'Restoring dev dependencies...'
+@npm install --quiet
 endef
 
 # lambda-update-makefile updates this makefile.
 define lambda-update-makefile
-	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/lambda.mk -O /tmp/lambda.mk 2>/dev/null
-	@if ! grep -q $(LAMBDA_MK_VERSION) /tmp/lambda.mk; then cp /tmp/lambda.mk lambda.mk && echo "lambda.mk updated"; else echo "lambda.mk is up-to-date"; fi
+@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/lambda.mk -O /tmp/lambda.mk 2>/dev/null
+@if ! grep -q $(LAMBDA_MK_VERSION) /tmp/lambda.mk; then cp /tmp/lambda.mk lambda.mk && echo "lambda.mk updated"; else echo "lambda.mk is up-to-date"; fi
 endef


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-4358

Goal: send lambda logs to Datadog logs via the [Datadog Lambda Layer](https://docs.datadoghq.com/serverless/datadog_lambda_library).

Problem: the DD Lambda Layer only supports Node, Python, and the "Custom"/`provided.al2` Lambda runtimes.

Solution:
- [x] Update to latest aws-lambda-go to support the new [Lambda Runtime API](https://github.com/aws/aws-lambda-go/pull/298).
  This Runtime API is the protocol that governs how lambda code gets invoked in the `provided.al2` runtime.
- [ ] (this PR) Update build process to create zip files with an additional binary named `bootstrap`. This is the same as the built Go program but just named `bootstrap` to satisfy what is required by the `provided.al2` runtime.
- [ ] Update code in catapult to deploy lambdas using the `provided.al2` runtime and the DD Lambda Layer.
- [ ] Remove old binary from zip files.
