### PR TITLE
Remove a noisy log line

### DIFF
--- a/cmd/dynamodb/main.go
+++ b/cmd/dynamodb/main.go
@@ -180,7 +180,6 @@ func toItem(value events.DynamoDBAttributeValue, pathSoFar string) interface{} {
 		doc := map[string]interface{}{}
 		for k, v := range value.Map() {
 			path := fmt.Sprintf("%s.%s", pathSoFar, k)
-			fmt.Println(path)
 			// When we send workflows to ES, including the state machine explodes the number of fields.
 			if path == "Workflow.workflowDefinition.stateMachine" {
 				continue


### PR DESCRIPTION
This line is responsible for a ton of logs that we don't care about at all: https://app.datadoghq.com/logs?from_ts=1615242176692&index=%2A&live=true&query=env%3Aproduction%20service%3Addb-to-es&to_ts=1615243076692