### PR TITLE
[automated] Upgrade to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/ddb-to-es
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: circleci/golang:1.16-stretch
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ APP_NAME ?= $(REPONAME)
 
 .PHONY: test build run $(PKGS) install_deps
 
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.16))
 
 test: $(PKGS)
 
@@ -29,4 +29,4 @@ generate:
 
 install_deps:
 	go mod vendor
-	go build -o bin/go-bindata ./vendor/github.com/kevinburke/go-bindata/go-bindata
+	go build -mod=vendor -o bin/go-bindata ./vendor/github.com/kevinburke/go-bindata/go-bindata


### PR DESCRIPTION
This PR migrates to Go 1.16.

If the build passes, no action is required by you, infra will merge and deploy this. For any questions, reach out to @taylor-sutton (Slack `taylor`) or #oncall-infra.
