### PR TITLE
[Automated] migrate to next-gen CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/ddb-to-es
+    working_directory: ~/go/src/github.com/Clever/ddb-to-es
     docker:
     - image: circleci/golang:1.13-stretch
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2


### PR DESCRIPTION
Migrate from previous-gen CircleCI Golang image to next gen one.

Previous gen images are getting deprecated, and newer ones are supposed to be faster.
