### PR TITLE
[automated] Lambdas on Arm

### DIFF
--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -1,22 +1,23 @@
 run:
   type: lambda
+  architecture: x86_64
 env:
-  - ELASTICSEARCH_URL
-  - ELASTICSEARCH_INDICES
-  - FAIL_ON_ERROR
-  - DYNAMODB_STREAM_ARN
+- ELASTICSEARCH_URL
+- ELASTICSEARCH_INDICES
+- FAIL_ON_ERROR
+- DYNAMODB_STREAM_ARN
 resources:
   max_mem: 0.128
 shepherds:
-- "mohit.gupta@clever.com"
-team: "eng-infra"
+- mohit.gupta@clever.com
+team: eng-infra
 lambda:
   Timeout: 200
   Events:
     ProcessDynamoDBStream:
       Type: DynamoDB
       Properties:
-        Stream: "${DYNAMODB_STREAM_ARN}"
+        Stream: ${DYNAMODB_STREAM_ARN}
         BatchSize: 200
         StartingPosition: LATEST
 pod_config:


### PR DESCRIPTION
PR created via Microplane

Please merge yourself!

But first please read this PR message, especially for node lambdas. But tbh.. for Go lambdas, if you merge without reading, you should be fine :D

## What does this PR do?

This PR likely updates the lambdas/lambdas to run on an arm processor, enabling us to run our lambdas on AWS Graviton. With Graviton, we can get up to 34% better price performance, according to AWS. Read more [here](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/).

Note: One caveat is that lambdas running in us-west-1 must run on `x86_64`, as that region doesn't support `arm`, so repos with at least one lambda running in `us-west-1` will not have the `lambda.mk` file updated and will have `architecture: x86_64`.

As a side effect of the yaml library used, you may see slight formatting changes on launch yaml files (such as quotes removed on strings) and/or unrelated additions to the `lambda.mk` file as it is updated to the newest version.

## Before merging

Go lambdas should be able to deploy with no additional changes, beyond what is included in this PR.

On the other hand, Node lambdas may need to have dependencies updated to pull in new versions that support ARM. A simple way to check this, is:

1. Deploy this build to clever-dev with `ark start APP -e clever-dev -b lambdas-on-arm`
2. Go to go/hubble and search for the lambda
3. Update the `namespace and queue` to `clever-dev`
4. Run the lambda with a sample input. If it works as expected, we should be able to safely deploy to production.
5. If you see any issues, we may need to update the dependency in question to a newer version that supports Arm. OR, we can have the lambda continue running on x86_64 by setting the `architecture` to `x86_64` instead of `arm64` in the launch config.

PLEASE FEEL FREE TO APPROVE AND MERGE YOURSELF! Thank you :party-blob:! If you don't, I will get to it, but if you do, you'll help reduce the number of lambdas I need to merge down from 200!

## After merging

Monitor metrics and logs to ensure that you don't see anything out of the ordinary. If you do, feel free to rollback and contact Nikhil and/or #oncall-infra.

If you have questions, please ask here or in #oncall-infra.
