### PR TITLE
revert memory bump

### DIFF
--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -7,7 +7,7 @@ env:
 - FAIL_ON_ERROR
 - DYNAMODB_STREAM_ARN
 resources:
-  max_mem: 0.256
+  max_mem: 0.128
 shepherds:
 - mohit.gupta@clever.com
 team: eng-infra


### PR DESCRIPTION
this was done before we knew ES was the problem

reverting back to what it was before: https://github.com/Clever/ddb-to-es/commit/38cc91372d177819296f2916510367b6b3d3d529

max memory use over the last week:

![image](https://user-images.githubusercontent.com/72655/192886204-4b9ea49e-af42-466c-9030-1e8e42d28e78.png)
