### PR TITLE
migrate lambdas to use graviton

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,8 @@ jobs:
     docker:
     - image: cimg/go:1.16
     - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+      environment:
+      - discovery.type: single-node
     environment:
       GOPRIVATE: github.com/Clever/*
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts

--- a/lambda.mk
+++ b/lambda.mk
@@ -1,7 +1,7 @@
 # This is the default Clever lambda Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-LAMBDA_MK_VERSION := 0.2.3
+LAMBDA_MK_VERSION := 0.3.0
 SHELL := /bin/bash
 
 GOPATH ?= $(HOME)/go
@@ -10,7 +10,7 @@ GOPATH ?= $(HOME)/go
 # arg1: pkg path
 # arg2: executable name
 define lambda-build-go
-@GOOS=linux go build -o bin/$(2) $(1)
+@GOOS=linux GOARCH=arm64 go build -o bin/$(2) $(1)
 # provided.al2 requires executable to be named `boostrap`
 # During migration include both `bootstrap` and `$(2)` in the
 # zip file, and once everything is on al2, remove `$(2)`
@@ -27,6 +27,8 @@ define lambda-build-node
 @rm -r node_modules/
 @npm install --quiet --production
 @cp -r node_modules/ bin/node_modules/
+@echo 'Copying kvconfig.yml...'
+@cp kvconfig.yml bin/kvconfig.yml
 @echo 'Creating zip file...'
 @(cd bin/ && zip -qr $(1).zip *)
 @echo 'Restoring dev dependencies...'

--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -1,6 +1,6 @@
 run:
   type: lambda
-  architecture: x86_64
+  architecture: arm64
 env:
 - ELASTICSEARCH_URL
 - ELASTICSEARCH_INDICES


### PR DESCRIPTION
PR created via Microplane

Please merge yourself!

But first please read this PR message, especially for node lambdas. But tbh.. for Go lambdas, if you merge without reading, you should be fine :D

## What does this PR do?

This is a followup to similar PRs that were created back in April 2022. At that point we migrated all lambdas in us-west-2, us-east-1 and us-east-2 to use AWS Graviton. But AWS hadn't released support for us-west-1 back then. Now that this support is available we will migrated the rest of our lambdas to use arm architecture.

This PR updates the lambdas/lambdas to run on an arm processor, enabling us to run our lambdas on AWS Graviton. With Graviton, we can get up to 34% better price performance, according to AWS. Read more [here](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/).


As a side effect of the yaml library used, you may see slight formatting changes on launch yaml files (such as quotes removed on strings) and/or unrelated additions to the `lambda.mk` file as it is updated to the newest version.

## Before merging

Go lambdas should be able to deploy with no additional changes, beyond what is included in this PR.

On the other hand, Node lambdas may need to have dependencies updated to pull in new versions that support ARM. A simple way to check this, is:

1. Deploy this build to clever-dev with `ark start APP -e clever-dev -b lambdas-on-arm`
2. Go to go/hubble and search for the lambda
3. Update the `namespace and queue` to `clever-dev`
4. Run the lambda with a sample input. If it works as expected, we should be able to safely deploy to production.
5. If you see any issues, we may need to update the dependency in question to a newer version that supports Arm. OR, we can have the lambda continue running on x86_64 by setting the `architecture` to `x86_64` instead of `arm64` in the launch config.

PLEASE FEEL FREE TO APPROVE AND MERGE YOURSELF! Thank you :party-blob:! If you don't, I will get to it, but if you do, you'll help reduce the number of lambdas I need to merge down from 200!

## After merging

Monitor metrics and logs to ensure that you don't see anything out of the ordinary. If you do, feel free to rollback and contact Nikhil and/or #oncall-infra.

If you have questions, please ask here or in #oncall-infra.
