### PR TITLE
Set MaxConcurrent to 55

### DIFF
--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -13,6 +13,7 @@ shepherds:
 team: eng-infra
 lambda:
   Timeout: 200
+  MaxConcurrent: 55
   Events:
     ProcessDynamoDBStream:
       Type: DynamoDB


### PR DESCRIPTION
https://app.datadoghq.com/monitors/92800048?from_ts=1692284248000&to_ts=1692285448000&source=monitor_notif&eval_ts=1692285448000 this monitor is firing. I noticed that lambda is getting throttled as it was set to MaxConcurrent of 45. This was set manually in the console (during a flare) and never reset. 

But if you let the lambda scale then we start seeing https://app.datadoghq.com/logs?query=env%3Aproduction%20service%3Addb-to-es%20%40log_title%3Adocument-write-failed&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1692278695811&to_ts=1692293095811&live=true errors writing to the es cluster.

For now lets bump this number to 55 which is the max number where we rarely see any errors