### PR TITLE
remove info logs that are not used for anything

### DIFF
--- a/cmd/dynamodb/main.go
+++ b/cmd/dynamodb/main.go
@@ -31,8 +31,7 @@ var ErrNoRecords = errors.New("no records contained in event")
 // Handler is your Lambda function handler.
 // The return signature can be empty, a single error, or a return value (struct or string) and error.
 func Handler(ctx context.Context, event events.DynamoDBEvent) error {
-	log.InfoD("process-records-start", logger.M{"count": len(event.Records)})
-	if docs, err := processRecords(event.Records, DBClient); err != nil {
+	if _, err := processRecords(event.Records, DBClient); err != nil {
 		if FailOnError {
 			return err
 		}
@@ -43,8 +42,6 @@ func Handler(ctx context.Context, event events.DynamoDBEvent) error {
 		log.InfoD("process-records-failure", logger.M{
 			"error": errorMsg,
 		})
-	} else {
-		log.InfoD("process-records-success", logger.M{"count": len(event.Records), "docs": len(docs)})
 	}
 
 	return nil
@@ -120,7 +117,6 @@ func processRecords(records []events.DynamoDBEventRecord, db es.DB) ([]es.Doc, e
 		}
 	}
 
-	log.InfoD("write-docs-start", logger.M{"count": len(docs)})
 	if err := db.WriteDocs(docs); err != nil {
 		return nil, err
 	}

--- a/es/db.go
+++ b/es/db.go
@@ -81,16 +81,8 @@ func NewDB(config *DBConfig, indices []string, lg logger.KayveeLogger) (*Elastic
 func (db *Elasticsearch) WriteDocs(docs []Doc) error {
 	bulkRequest := db.client.Bulk()
 
-	countUpdate := 0
-	countDelete := 0
-
 	for _, doc := range docs {
 		for _, index := range db.indices {
-			if doc.Op == OpTypeUpdate {
-				countUpdate += 1
-			} else if doc.Op == OpTypeDelete {
-				countDelete += 1
-			}
 			req := toESRequest(doc, index)
 			// TODO: handle nil (error) cases better. For now let's just keep going
 			if req != nil {
@@ -98,8 +90,6 @@ func (db *Elasticsearch) WriteDocs(docs []Doc) error {
 			}
 		}
 	}
-
-	db.lg.InfoD("write-docs-request", logger.M{"countUpdate": countUpdate, "countDelete": countDelete})
 
 	if bulkRequest.NumberOfActions() == 0 {
 		return nil


### PR DESCRIPTION
https://github.com/Clever/ddb-to-es/pull/67 these info logs were added a year ago to do some investigation into the workings on ddb-to-es. AFAIK nothing came of it and these logs are not used anymore.

Additionally I also removed `process-records-success` because that is also not used anywhere 🤷.

This should save us ~$420 per month in datadog logs indexed cost + some more in ingested bytes cost