### PR TITLE
reduce max concurrency

### DIFF
--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -13,7 +13,7 @@ shepherds:
 team: eng-infra
 lambda:
   Timeout: 200
-  MaxConcurrent: 55
+  MaxConcurrent: 50
   Events:
     ProcessDynamoDBStream:
       Type: DynamoDB


### PR DESCRIPTION
Jira: https://clever.atlassian.net/browse/INFRANG-5554

Overview:
We see quite a few of `rejected execution of org.elasticsearch.common.util.concurrent.TimedRunnable@12922a2 on EWMATrackingEsThreadPoolExecutor[name = vbd8a8T/write, queue capacity = 200, task execution EWMA = 7.8ms, org.elasticsearch.common.util.concurrent.EWMATrackingEsThreadPoolExecutor@728ab38b[Running, pool size = 4, active threads = 4, queued tasks = 203, completed tasks = 387092730]]` when there are a lot of workflows running.

Lets try lowering max concurrency to see if that helps!