### PR TITLE
changes pod group to us-west-2

### DIFF
--- a/launch/ddb-to-es.yml
+++ b/launch/ddb-to-es.yml
@@ -2,14 +2,14 @@ run:
   type: lambda
   architecture: arm64
 env:
-- ELASTICSEARCH_URL
-- ELASTICSEARCH_INDICES
-- FAIL_ON_ERROR
-- DYNAMODB_STREAM_ARN
+  - ELASTICSEARCH_URL
+  - ELASTICSEARCH_INDICES
+  - FAIL_ON_ERROR
+  - DYNAMODB_STREAM_ARN
 resources:
   max_mem: 0.128
 shepherds:
-- mohit.gupta@clever.com
+  - mohit.gupta@clever.com
 team: eng-infra
 lambda:
   Timeout: 200
@@ -22,9 +22,9 @@ lambda:
         BatchSize: 200
         StartingPosition: LATEST
 pod_config:
-  group: us-west-1
+  group: us-west-2
 deploy_config:
   canaryInProd: false
   autoDeployEnvs:
-  - clever-dev
-  - production
+    - clever-dev
+    - production


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6147

# About
https://github.com/Clever/ark-config/pull/4592

This PR changes the pod region to `us-west-2` for single region us-west-1 lambdas.

In order to move the stream to a new region, I will first deploy the new lambda, then suspend the old one before stopping it in order to reduce the amount of time with duplicate writes.

# Testing
I will first perform the rollout in clever-dev, then in prod.
