### PR TITLE
fix(INFRANG-6623): Update golang.mk

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.0.1
+GOLANG_MK_VERSION := 1.3.0
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -47,6 +47,8 @@ golang-ensure-curl-installed:
 # Golint is a tool for linting Golang code for common errors.
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
+# this package is deprecated and frozen
+# Infra recomendation is to eventaully move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
@@ -74,14 +76,6 @@ endef
 # golang-lint-deps-strict requires the golint tool for golang linting.
 golang-lint-deps-strict: $(GOLINT) $(FGT)
 
-# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
-# errors are found.
-# arg1: pkg path
-define golang-lint-strict
-@echo "LINTING $(1)..."
-@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); find $${PKG_PATH}/*.go -type f | grep -v gen_ | xargs $(FGT) $(GOLINT)
-endef
-
 # golang-test-deps is here for consistency
 golang-test-deps:
 
@@ -100,6 +94,21 @@ golang-test-strict-deps:
 define golang-test-strict
 @echo "TESTING $(1)..."
 @go test -v -race $(1)
+endef
+
+# golang-test-strict-cover-deps is here for consistency
+golang-test-strict-cover-deps:
+
+# golang-test-strict-cover uses the Go toolchain to run all tests in the pkg with the race and cover flag.
+# appends coverage results to coverage.txt
+# arg1: pkg path
+define golang-test-strict-cover
+@echo "TESTING $(1)..."
+@go test -v -race -cover -coverprofile=profile.tmp -covermode=atomic $(1)
+@if [ -f profile.tmp ]; then \
+  cat profile.tmp | tail -n +2 >> coverage.txt; \
+  rm profile.tmp; \
+fi;
 endef
 
 # golang-vet-deps is here for consistency
@@ -132,23 +141,51 @@ golang-test-all-strict-deps: golang-fmt-deps golang-lint-deps-strict golang-test
 # arg1: pkg path
 define golang-test-all-strict
 $(call golang-fmt,$(1))
-$(call golang-lint-strict,$(1))
+$(call golang-lint,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
 endef
 
-# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# golang-test-all-strict-cover-deps: installs all dependencies needed for different test cases.
+golang-test-all-strict-cover-deps: golang-fmt-deps golang-lint-deps-strict golang-test-strict-cover-deps golang-vet-deps
+
+# golang-test-all-strict-cover calls fmt, lint, vet and test on the specified pkg with strict and cover
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict-cover
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test-strict-cover,$(1))
+endef
+
+# golang-build: builds a golang binary
 # arg1: pkg path
 # arg2: executable name
 define golang-build
-@echo "BUILDING..."
-@if [ -z "$$CI" ]; then \
-	go build -o bin/$(2) $(1); \
-else \
-	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
-fi;
+@echo "BUILDING $(2)..."
+@CGO_ENABLED=0 go build -o bin/$(2) $(1);
 endef
+
+# golang-debug-build: builds a golang binary with debugging capabilities
+# arg1: pkg path
+# arg2: executable name
+define golang-debug-build
+@echo "BUILDING $(2) FOR DEBUG..."
+@CGO_ENABLED=0 go build -gcflags="all=-N -l" -o bin/$(2) $(1);
+endef
+
+# golang-cgo-build: builds a golang binary with CGO
+# arg1: pkg path
+# arg2: executable name
+define golang-cgo-build
+@echo "BUILDING $(2) WITH CGO ..."
+@CGO_ENABLED=1 go build -installsuffix cgo -o bin/$(2) $(1);
+endef
+
+# golang-setup-coverage: set up the coverage file
+golang-setup-coverage:
+	@echo "mode: atomic" > coverage.txt
 
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:


### PR DESCRIPTION
JIRA: 
[https://clever.atlassian.net/browse/INFRANG-6623](https://clever.atlassian.net/browse/INFRANG-6623)

Updating golang.mk to [latest version](https://github.com/Clever/dev-handbook/blob/8daf5996b7696ae20e673c11e37f8543b69ba4e2/make/golang-v1.mk). 

This change disables CGO builds by default, and creates two separate targets for CGO and debug builds.

<details>Build produced with updated golang.mk</details>
